### PR TITLE
:rocket: test:SSL인증서 없이 http 요청 허용 위한 시도-vercel.config수정

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,14 @@
-
 {
-    "rewrites":  [
-      {"source": "/(.*)", "destination": "/"}
-    ]
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "http://3.37.196.93:8080/$1",
+      "has": [
+        {
+          "type": "host",
+          "value": "rental-market.vercel.app"
+        }
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
- 서버쪽 SSL 인증서 없어서, https vercel 주소에서 요청 현재 막혀있는 상태 (로그인 인증 토큰과 무관, 배포 주소의 문제입니다)
- vercel.config 에 destination 부분에 지기님 서버 테스트로 넣었고 
-vercel 대시보드에 환경변수 name, value 등 을 추가해보는 시도를 했습니다. 